### PR TITLE
Nepi Detailed Report: Fix 500 when there are no users

### DIFF
--- a/nepi/main/tests/test_reports.py
+++ b/nepi/main/tests/test_reports.py
@@ -307,6 +307,25 @@ class TestDownloadableReportView(TestReportBase):
         except StopIteration:
             pass  # expected
 
+    def test_detailed_report_values_no_users(self):
+        group = SchoolGroupFactory()
+        country = group.school.country
+        school = group.school
+        data = {'country': country.name,
+                'school': school.pk,
+                'schoolgroup': 'all',
+                'report-type': 'values'}
+
+        self.client.login(username=self.icap.username, password="test")
+        response = self.client.post(self.report_download_url, data)
+        self.assertEquals(response.status_code, 200)
+
+        row = ('participant_id,country,group,percent_complete,'
+               'total_time_elapsed,actual_time_spent,completion_date\r\n')
+        self.assertEquals(row, response.streaming_content.next())  # header row
+        with self.assertRaises(StopIteration):
+            response.streaming_content.next()
+
 
 class TestBaseReportMixin(TestReportBase):
 

--- a/nepi/main/views.py
+++ b/nepi/main/views.py
@@ -637,7 +637,7 @@ class BaseReportMixin(object):
         group_id = request.POST.get('schoolgroup', self.all)
         (country_name, school_id) = self.get_country_and_school(request)
         groups = None
-        users = None
+        users = User.objects.none()
 
         if group_id != self.all:  # requesting a single group
             groups = Group.objects.filter(id=group_id)


### PR DESCRIPTION
* return an empty queryset rather than None in situation where the report query (by country, school, group) has no users.
* add tests

resolves Sentry error: https://sentry.ccnmtl.columbia.edu/sentry-internal/nepi/group/705/#user