### PR TITLE
make DosageActivity JSON serializable

### DIFF
--- a/nepi/activities/models.py
+++ b/nepi/activities/models.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from datetime import datetime
 from django import forms
 from django.contrib.auth.models import User
@@ -823,7 +824,7 @@ class DosageActivity(models.Model):
         return dict(
             explanation=self.explanation,
             question=self.question,
-            ml_nvp=self.ml_nvp,
+            ml_nvp=str(self.ml_nvp),
             times_day=self.times_day,
             weeks=self.weeks)
 
@@ -832,7 +833,7 @@ class DosageActivity(models.Model):
         return cls.objects.create(
             explanation=d.get('explanation', None),
             question=d.get('question', None),
-            ml_nvp=d.get('ml_nvp', 0.0),
+            ml_nvp=Decimal(d.get('ml_nvp', 0.0)),
             times_day=d.get('times_day', 0),
             weeks=d.get('weeks', 0)
         )

--- a/nepi/activities/tests/factories.py
+++ b/nepi/activities/tests/factories.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import factory
 from nepi.activities.models import ConversationScenario, \
     Conversation, ConvClick, RetentionRateCard, RetentionClick, \
@@ -103,6 +104,6 @@ class DosageActivityFactory(factory.DjangoModelFactory):
     FACTORY_FOR = DosageActivity
     explanation = 'the explanation'
     question = 'the question'
-    ml_nvp = 1.5
+    ml_nvp = Decimal(1.5)
     times_day = 3
     weeks = 5

--- a/nepi/activities/tests/test_models.py
+++ b/nepi/activities/tests/test_models.py
@@ -14,6 +14,7 @@ from nepi.activities.tests.factories import ConvClickFactory, \
     MonthFactory, CorrectDayFactory, ImageInteractiveFactory, ARTCardFactory, \
     AdherenceCardFactory
 from nepi.main.tests.factories import UserFactory
+import json
 
 
 class TestConvClick(TestCase):
@@ -376,9 +377,16 @@ class TestDosageActivity(TestCase):
         d = block.as_dict()
         self.assertEquals(block.explanation, d['explanation'])
         self.assertEquals(block.question, d['question'])
-        self.assertEquals(block.ml_nvp, d['ml_nvp'])
+        self.assertEquals(block.ml_nvp, Decimal(d['ml_nvp']))
         self.assertEquals(block.times_day, d['times_day'])
         self.assertEquals(block.weeks, d['weeks'])
+
+    def test_json_serialize_round_trip(self):
+        block = DosageActivityFactory()
+        d1 = block.as_dict()
+        serialized = json.dumps(d1)
+        d2 = json.loads(serialized)
+        self.assertEquals(d1['ml_nvp'], d2['ml_nvp'])
 
     def test_create_from_dict(self):
         original = DosageActivityFactory()


### PR DESCRIPTION
see: https://sentry.ccnmtl.columbia.edu/sentry-internal/nepi/group/738/

the DecimalField on DosageActivity isn't JSON serializable with the standard
json library. Need to dumb it down to a string when it comes out of as_dict()