### PR TITLE
Waffle edit hierarchy permissions

### DIFF
--- a/nepi/main/views.py
+++ b/nepi/main/views.py
@@ -97,6 +97,13 @@ class NepiPageView(LoggedInMixin, InitializeHierarchyMixin, PageView):
 class NepiEditView(LoggedInMixinStaff, InitializeHierarchyMixin, EditView):
     template_name = "pagetree/edit_page.html"
 
+    def get_context_data(self, path):
+        ctx = super(NepiEditView, self).get_context_data(path)
+
+        edit_flag = '%s-edit' % self.hierarchy_name
+        ctx['editable'] = flag_is_active(self.request, edit_flag)
+        return ctx
+
 
 class HomeView(LoggedInMixin, View):
     '''redoing so that it simply redirects people where they need to be'''

--- a/nepi/templates/pagetree/edit_page.html
+++ b/nepi/templates/pagetree/edit_page.html
@@ -148,21 +148,21 @@
 {% endblock %}
  
 {% block content %}
-  
-  <h1><small>{{section.hierarchy.name}}</small>&nbsp;&nbsp; {{ section.label }}</h1>
-  <br />
- 
- <ul class="edit-page-nav nav nav-tabs">
+    <h1><small>{{section.hierarchy.name}}</small>&nbsp;&nbsp; {{ section.label }} {% if not editable %}<i class="icon-lock"></i>{% endif %}</h1>
+    <br />
+  <ul class="edit-page-nav nav nav-tabs">
      <li {% if section.is_root %}class="active"{% endif%}>
          <a href="#content-tree" data-toggle="tab">Hierarchy</a>
      </li>
-      <li {% if not section.is_root %}class="active"{% endif%}>
-          <a href="#edit-blocks-tab" data-toggle="tab">Edit Blocks</a>
-     </li>
-     <li><a href="#children-tab" data-toggle="tab">Children</a></li>
-     <li><a href="#add-pageblock-tab" data-toggle="tab">Add Pageblock</a></li>
-     <li><a href="#edit-page-tab" data-toggle="tab">Edit Section</a></li>
-     <li><a href="#move-section-tab" data-toggle="tab">Move Section</a></li>
+     {% if editable %}
+         <li {% if not section.is_root %}class="active"{% endif%}>
+              <a href="#edit-blocks-tab" data-toggle="tab">Edit Blocks</a>
+         </li>
+         <li><a href="#children-tab" data-toggle="tab">Children</a></li>
+         <li><a href="#add-pageblock-tab" data-toggle="tab">Add Pageblock</a></li>
+         <li><a href="#edit-page-tab" data-toggle="tab">Edit Section</a></li>
+         <li><a href="#move-section-tab" data-toggle="tab">Move Section</a></li>
+     {% endif %}
      <li><a href="#history-tab" data-toggle="tab">History</a></li>
  </ul>
  


### PR DESCRIPTION
A quick approach to disallow editing of a particular hierarchy based on a waffle flag.
This lets us shutdown editing of the English hierarchy to prevent inadvertant translation,
and lock down editing of the language hierarchies to a single staff member.