### PR TITLE
Conversation.complete_dialog - Remove max_length constraint

### DIFF
--- a/nepi/activities/migrations/0002_auto_20150625_1336.py
+++ b/nepi/activities/migrations/0002_auto_20150625_1336.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('activities', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='conversation',
+            name='complete_dialog',
+            field=models.TextField(null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/nepi/activities/models.py
+++ b/nepi/activities/models.py
@@ -23,7 +23,7 @@ class Conversation(models.Model):
     response_one = models.CharField(max_length=255, null=True, blank=True)
     response_two = models.CharField(max_length=255, null=True, blank=True)
     response_three = models.CharField(max_length=255, null=True, blank=True)
-    complete_dialog = models.TextField(max_length=255, null=True, blank=True)
+    complete_dialog = models.TextField(null=True, blank=True)
 
     def __unicode__(self):
         return unicode(self.scenario_type)


### PR DESCRIPTION
Remove max_length=255 from the complete_dialog field. The constraint is not needed, is not enforced at the db level, but still interferes with form field validation.
https://docs.djangoproject.com/en/1.8/ref/models/fields/#textfield