### PR TITLE
Remove cross-hierarchy navigation

### DIFF
--- a/nepi/main/admin.py
+++ b/nepi/main/admin.py
@@ -40,8 +40,12 @@ admin.site.register(Country)
 admin.site.register(PendingTeachers, PendingTeacherAdmin)
 
 
+def section_hierarchy(obj):
+    return obj.section.hierarchy.name
+
+
 class UserPageVisitAdmin(admin.ModelAdmin):
     search_fields = ['user__username']
-    list_display = ['user', 'section', 'status']
+    list_display = ['user', 'section', section_hierarchy, 'status']
 
 admin.site.register(UserPageVisit, UserPageVisitAdmin)

--- a/nepi/templates/main/page.html
+++ b/nepi/templates/main/page.html
@@ -159,7 +159,7 @@
 {% block contentnav %}
 {% with previous=section.get_previous next_section=section.get_next %}
     <ul class="pager">
-        {% if not section.is_root and previous%}
+        {% if not section.is_root and previous and not previous.is_root %}
           <li class="previous">
                 <a href="{{ previous.get_absolute_url }}">&larr; {% trans 'Previous' %}</a>
           </li>
@@ -167,10 +167,14 @@
         
         {% if next_section %}
             <li class="next">
+            {% if next_section.is_root %}
+                <a href="/">{% trans 'Home' %} &rarr;</a>            
+            {% else %} 
                 <a href="{{ next_section.get_absolute_url }}"
                  class="{% ifsubmitted section %}{% else %}disabled{%endifsubmitted%}">
                     {% trans 'Next' %} &rarr;
                 </a>
+            {% endif %}
             </li>
         {% endif %}
     </ul>


### PR DESCRIPTION
some users have inadvertently wandered into the French hierarchy after they finish the English hierarchy.