### PR TITLE
Update configuration for UpdateConversationView

### DIFF
--- a/nepi/activities/tests/test_views.py
+++ b/nepi/activities/tests/test_views.py
@@ -11,7 +11,8 @@ from nepi.activities.models import ConversationResponse, RetentionResponse, \
     CalendarResponse
 from nepi.activities.tests.factories import ConversationScenarioFactory, \
     RetentionRateCardFactory, CalendarChartFactory, IncorrectDayOneFactory, \
-    IncorrectDayTwoFactory, CorrectDayFactory
+    IncorrectDayTwoFactory, CorrectDayFactory, GoodConversationFactory
+from nepi.activities.views import UpdateConversationView
 from nepi.main.tests.factories import UserProfileFactory
 
 
@@ -295,3 +296,22 @@ class TestCalendarResponseView(TestCase):
 
         upv = UserPageVisit.objects.get(user=up.user, section=self.section)
         self.assertEquals(upv.status, "complete")
+
+
+class TestUpdateConversationView(TestCase):
+
+    def test_get(self):
+        conversation = GoodConversationFactory()
+        url = reverse('update_conversation', kwargs={'pk': conversation.id})
+
+        up = UserProfileFactory()
+        self.client.login(username=up.user.username, password="test")
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+
+    def test_get_context_data(self):
+        view = UpdateConversationView()
+        view.object = GoodConversationFactory()
+
+        ctx = view.get_context_data()
+        self.assertEquals(ctx['scenario'], view.object.get_scenario())

--- a/nepi/activities/views.py
+++ b/nepi/activities/views.py
@@ -51,6 +51,8 @@ class CreateConversationView(CreateView):
 class UpdateConversationView(UpdateView):
     model = Conversation
     template_name = 'activities/conversation_add_or_edit.html'
+    fields = ['scenario_type', 'text_one', 'response_one', 'response_two',
+              'response_three', 'complete_dialog']
 
     def get_context_data(self, **kwargs):
         ctx = super(UpdateConversationView, self).get_context_data(**kwargs)


### PR DESCRIPTION
as of Django 1.8, [a fields or form_class definition is required] (https://docs.djangoproject.com/en/1.8/ref/class-based-views/mixins-editing/#django.views.generic.edit.ModelFormMixin)

Resolves Sentry #852 -- "ImproperlyConfigured: Using ModelFormMixin (base class of UpdateConversationView) without the 'fields' attribute is prohibited."