### PR TITLE
Dosage Activity: Only accept 2 digits & 2 decimal places

### DIFF
--- a/nepi/templates/activities/dosageactivity_js.html
+++ b/nepi/templates/activities/dosageactivity_js.html
@@ -23,7 +23,7 @@ jQuery(document).ready(function() {
         jQuery('.control-group').removeClass('error');
         
         var success = true;
-        var re = new RegExp(/^\d{0,4}(\.\d{0,2})?$/);
+        var re = new RegExp(/^\d{0,2}(\.\d{0,2})?$/);
         var dig = new RegExp(/^\d+$/);
         
     	var nvp = jQuery(inputs[0]).val();


### PR DESCRIPTION
fixes sentry error "quantize result has too many digits for current context"