### PR TITLE
Indicate hierarchy completeness

### DIFF
--- a/nepi/main/models.py
+++ b/nepi/main/models.py
@@ -387,6 +387,7 @@ class DetailedReport(PagetreeReport):
 
     def standalone_columns(self):
         from nepi.main.templatetags.progressreport import average_quiz_score
+        from nepi.main.templatetags.progressreport import completed
 
         return [
             StandaloneReportColumn(
@@ -402,6 +403,10 @@ class DetailedReport(PagetreeReport):
                 'Groups',
                 lambda x: ','.join(
                     x.profile.get_groups_by_hierarchy(self.hierarchy))),
+            StandaloneReportColumn(
+                'completed', 'profile', 'boolean',
+                'pages visits + pre + post tests',
+                lambda x: completed(x, self.hierarchy)),
             StandaloneReportColumn(
                 'percent_complete', 'profile', 'percent',
                 '% of hierarchy completed',

--- a/nepi/main/templatetags/progressreport.py
+++ b/nepi/main/templatetags/progressreport.py
@@ -110,6 +110,19 @@ def average_quiz_score(users, hierarchy, cls):
         return int(round(score * 100))
 
 
+def completed(user, hierarchy):
+    if user.profile.percent_complete(hierarchy.get_root()) < 100:
+        return False
+
+    if average_quiz_score([user], hierarchy, 'pretest') < 0:
+        return False
+
+    if average_quiz_score([user], hierarchy, 'posttest') < 0:
+        return False
+
+    return True
+
+
 @register.simple_tag
 def display_average_quiz_score(user, hierarchy, css_extra_contains):
     score = average_quiz_score([user], hierarchy, css_extra_contains)

--- a/nepi/main/tests/test_reports.py
+++ b/nepi/main/tests/test_reports.py
@@ -271,9 +271,10 @@ class TestDownloadableReportView(TestReportBase):
             users, groups = view.get_users_and_groups(request, self.hierarchy)
 
             rows = view.get_detailed_report_values(self.hierarchies, users)
-            row = ['participant_id', 'country', 'group', 'percent_complete',
-                   'total_time_elapsed', 'actual_time_spent',
-                   'completion_date', 'pre-test score', 'post-test score']
+            row = ['participant_id', 'country', 'group', 'completed',
+                   'percent_complete', 'total_time_elapsed',
+                   'actual_time_spent', 'completion_date', 'pre-test score',
+                   'post-test score']
             self.assertEquals(rows.next(), row)
 
             # expecting 4 user results to show up
@@ -312,6 +313,10 @@ class TestDownloadableReportView(TestReportBase):
         self.assertEquals(rows.next(), row)
 
         row = ['', 'group', 'profile', 'list', 'Groups']
+        self.assertEquals(rows.next(), row)
+
+        row = ['', 'completed', 'profile', 'boolean',
+               'pages visits + pre + post tests']
         self.assertEquals(rows.next(), row)
 
         row = ['', 'percent_complete', 'profile', 'percent',
@@ -357,7 +362,7 @@ class TestDownloadableReportView(TestReportBase):
         response = self.client.post(self.report_download_url, data)
         self.assertEquals(response.status_code, 200)
 
-        row = ('participant_id,country,group,percent_complete,'
+        row = ('participant_id,country,group,completed,percent_complete,'
                'total_time_elapsed,actual_time_spent,completion_date,'
                'pre-test score,post-test score\r\n')
         self.assertEquals(row, response.streaming_content.next())  # header row


### PR DESCRIPTION
The data indicates a few users were able to bypass the clientside form completion tests and submit pre/post tests with incomplete responses. For reporting purposes, provide an aggregate completed boolean to indicate the user has traversed the entire module and has fully completed the pre-test & post-test.

resolves PMT #104304