### PR TITLE
remove django-tagging

### DIFF
--- a/nepi/settings_shared.py
+++ b/nepi/settings_shared.py
@@ -39,7 +39,6 @@ TEMPLATE_CONTEXT_PROCESSORS += [  # noqa
 
 INSTALLED_APPS += [  # noqa
     'sorl.thumbnail',
-    'tagging',
     'typogrify',
     'bootstrapform',
     'django_extensions',

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ rjsmin==1.0.12
 
 djangowind==0.14.3
 sorl==3.1
-tagging==0.3-pre
 typogrify==2.0.7
 django-staticmedia==0.2.2
 django-indexer==0.3.0


### PR DESCRIPTION
appears to be unused, and is blocking the path to 1.9.5