### PR TITLE
unpin pylint, remove unused python 2 dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pep8==1.7.1
 pyflakes==2.1.1
 mccabe==0.6.1
 pycodestyle==2.5.0
-enum34==1.1.6; python_version < '3.4'
 configparser==4.0.2
 flake8==3.7.7
 tornado==4.5.3 # pyup: <5.0
@@ -46,7 +45,7 @@ requests==2.22.0
 logilab-common==1.4.3
 logilab-astng==0.24.3
 editdistance==0.5.3
-pylint==1.9.4 # pyup: <2.0.0
+pylint==2.3.1
 six==1.12.0
 ipaddress==1.0.22
 text-unidecode==1.3  # for faker
@@ -78,8 +77,6 @@ django-jenkins==0.110.0
 django-smoketest==1.1.0
 django-extensions==2.2.1
 
-# needed for django-extensions
-typing==3.7.4.1; python_version < '3.5'
 
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
@@ -91,7 +88,6 @@ django-quizblock==1.2.5
 django-markwhat==1.6.2
 django-simple-captcha==0.5.12
 gunicorn==19.9.0
-futures==3.3.0; python_version < '3'
 s3transfer==0.2.1
 jmespath==0.9.4
 botocore>=1.12.194,<1.13.0
@@ -110,5 +106,4 @@ stevedore>=1.20.0 # Apache-2.0
 bandit==1.6.2
 django-ranged-response==0.2.0
 
-functools32==3.2.3-2; python_version < '3'
 entrypoints==0.3


### PR DESCRIPTION
A few other packages can probably be unpinned as well now that this is on python 3.