### PR TITLE
Update django-storages settings

### DIFF
--- a/nepi/settings_production.py
+++ b/nepi/settings_production.py
@@ -13,6 +13,13 @@ locals().update(
         INSTALLED_APPS=INSTALLED_APPS,  # noqa: F405
     ))
 
+
+# Update the django-storages parameter
+AWS_S3_OBJECT_PARAMETERS = {
+    'ACL': 'public-read',
+}
+
+
 try:
     from nepi.local_settings import *  # noqa: F403
 except ImportError:

--- a/nepi/settings_staging.py
+++ b/nepi/settings_staging.py
@@ -13,6 +13,13 @@ locals().update(
         INSTALLED_APPS=INSTALLED_APPS,  # noqa: F405
     ))
 
+
+# Update the django-storages parameter
+AWS_S3_OBJECT_PARAMETERS = {
+    'ACL': 'public-read',
+}
+
+
 try:
     from nepi.local_settings import *  # noqa: F403
 except ImportError:


### PR DESCRIPTION
The recent upgrade to django-storages 1.10 has broken the staging & production builds. This PR uses the new signature for the ACL as the old is fully deprecated in the 1.10 release. The settings are housed in `ccnmtlsettings` - I wanted to try this in one project before cutting a new `ccnmtlsettings` release.