### PR TITLE
Revert "Bump django-compressor from 2.4.1 to 3.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ django-indexer==0.3.0
 django-templatetag-sugar==1.0
 django-paging==0.2.5
 django-appconf==1.0.5
-django-compressor==3.1
+django-compressor==2.4.1
 django-statsd-mozilla==0.4.0
 raven==6.10.0
 sentry-sdk==1.5.1


### PR DESCRIPTION
Reverts ccnmtl/nepi#1833