### PR TITLE
INFRA-2608: Append ALLOWED_HOSTS to fix 400 on AWS TargetGroup Health…

### DIFF
--- a/nepi/settings_shared.py
+++ b/nepi/settings_shared.py
@@ -20,7 +20,7 @@ PROJECT_APPS = [
     'nepi.activities',
 ]
 
-ALLOWED_HOSTS = [
+ALLOWED_HOSTS += [
     'localhost',
     '.ccnmtl.columbia.edu',
     '.ctl.columbia.edu',


### PR DESCRIPTION
Fix http status code 400 on AWS TargetGroup HealthCheck because ALLOWED_HOSTS missing the EC2 instance IP