### PR TITLE
Enable sentry logging with init_sentry()

### DIFF
--- a/nepi/settings_production.py
+++ b/nepi/settings_production.py
@@ -1,5 +1,7 @@
-from nepi.settings_shared import *  # noqa: F403
-from ctlsettings.production import common
+from nepi.settings_shared import (
+    settings, project, base, STATIC_ROOT, INSTALLED_APPS
+)
+from ctlsettings.production import common, init_sentry
 
 
 locals().update(
@@ -22,3 +24,7 @@ try:
     from nepi.local_settings import *  # noqa: F403 F401
 except ImportError:
     pass
+
+
+if hasattr(settings, 'SENTRY_DSN'):
+    init_sentry(SENTRY_DSN)  # noqa F405

--- a/nepi/settings_staging.py
+++ b/nepi/settings_staging.py
@@ -1,5 +1,8 @@
-from nepi.settings_shared import *  # noqa: F403
-from ctlsettings.staging import common
+from nepi.settings_shared import (
+    settings, project, base, STATIC_ROOT, INSTALLED_APPS
+)
+from ctlsettings.staging import common, init_sentry
+
 
 locals().update(
     common(
@@ -21,3 +24,7 @@ try:
     from nepi.local_settings import *  # noqa: F403 F401
 except ImportError:
     pass
+
+
+if hasattr(settings, 'SENTRY_DSN'):
+    init_sentry(SENTRY_DSN)  # noqa F405


### PR DESCRIPTION
I'm not sure why this wasn't enabled yet.