### PR TITLE
Revert "Bump django-debug-toolbar from 5.2.0 to 6.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ django-bootstrap-form==3.4
 django-bootstrap3==25.1
 
 sqlparse==0.5.3
-django-debug-toolbar==6.0.0
+django-debug-toolbar==5.2.0
 
 django-waffle==5.0.0
 


### PR DESCRIPTION
Reverts ccnmtl/nepi#3055